### PR TITLE
Audio Manager - Queue and control audio playback in one place!

### DIFF
--- a/Swiftcord.xcodeproj/project.pbxproj
+++ b/Swiftcord.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 		DAAFB5C5282AB37500807B54 /* MediaControllerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAAFB5C4282AB37500807B54 /* MediaControllerView.swift */; };
 		DAAFB5C7282AB56B00807B54 /* AudioCenterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAAFB5C6282AB56B00807B54 /* AudioCenterManager.swift */; };
 		DAAFB5C9282B689000807B54 /* discord-loading-animation.json in Resources */ = {isa = PBXBuildFile; fileRef = DAAFB5C8282B689000807B54 /* discord-loading-animation.json */; };
+		DAAFB5CC282B879200807B54 /* FormatTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAAFB5CB282B879200807B54 /* FormatTime.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -256,6 +257,7 @@
 		DAAFB5C4282AB37500807B54 /* MediaControllerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaControllerView.swift; sourceTree = "<group>"; };
 		DAAFB5C6282AB56B00807B54 /* AudioCenterManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioCenterManager.swift; sourceTree = "<group>"; };
 		DAAFB5C8282B689000807B54 /* discord-loading-animation.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "discord-loading-animation.json"; sourceTree = "<group>"; };
+		DAAFB5CB282B879200807B54 /* FormatTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatTime.swift; sourceTree = "<group>"; };
 		DAB8CA4428291BBD009F079D /* DiscordAPI */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = DiscordAPI; path = ../DiscordAPI; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -573,6 +575,7 @@
 				DA32EF5527CA6DF900A9ED72 /* URLMimeType.swift */,
 				DA32EF4727C8ABFF00A9ED72 /* FormatDate.swift */,
 				DA585C9827E1F6AC00FA4EE0 /* CursorOnViewHover.swift */,
+				DAAFB5CB282B879200807B54 /* FormatTime.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -749,6 +752,7 @@
 				DA32EF5027C8D7E000A9ED72 /* MessageIsShrunk.swift in Sources */,
 				DAAFB5C5282AB37500807B54 /* MediaControllerView.swift in Sources */,
 				DA4A88EF27C34EB100720909 /* Levels.swift in Sources */,
+				DAAFB5CC282B879200807B54 /* FormatTime.swift in Sources */,
 				DA4A88E927C34CA900720909 /* ThreadMembersUpdate.swift in Sources */,
 				DA4A88FB27C35F2100720909 /* GuildRoleEvt.swift in Sources */,
 				DA520AC927D3A55D009FD740 /* SettingsView.swift in Sources */,

--- a/Swiftcord/Utils/AudioCenterManager.swift
+++ b/Swiftcord/Utils/AudioCenterManager.swift
@@ -8,6 +8,110 @@
 import Foundation
 import AVFoundation
 
+struct AudioCenterItems: Hashable {
+    let playerItem: AVPlayerItem
+    let filename: String
+    let from: String
+    let addedAt: Int
+}
+
 class AudioCenterManager: ObservableObject {
-    private let audioPlayer = AVQueuePlayer()
+    private let player = AVQueuePlayer()
+    private var timeObserverToken: Any?
+    
+    @Published public var queue: [AudioCenterItems] = []
+    @Published public var progress = 0.0
+    @Published public var duration = 0.0
+    @Published public var isSeeking = false
+    @Published public var isStopped = true
+    @Published public var isPlaying = false
+    
+    public func append(source: URL, filename: String, from: String) {
+        let playerItem = AVPlayerItem(url: source)
+        player.insert(playerItem, after: nil)
+        queue.append(AudioCenterItems(
+            playerItem: playerItem,
+            filename: filename,
+            from: from,
+            addedAt: Int(Date().timeIntervalSince1970)
+        ))
+    }
+    
+    public func play() {
+        player.volume = 1
+        player.play()
+        isPlaying = true
+        isStopped = false
+        progress = 0
+        duration = 0
+    }
+    public func playQueued(index: Int) {
+        queue.swapAt(index, 0)
+        player.pause()
+        player.removeAllItems()
+        for item in queue { player.insert(item.playerItem, after: nil) }
+        player.play()
+        player.seek(to: CMTime.zero)
+        isPlaying = true
+    }
+    public func resume() {
+        player.volume = 1
+        player.play()
+        isPlaying = true
+    }
+    public func pause() {
+        player.pause()
+        isPlaying = false
+    }
+    public func stop() {
+        isStopped = true
+        duration = 0
+        progress = 0
+        isPlaying = false
+    }
+    
+    public func seekTo(seconds: Double) {
+        isSeeking = true
+        player.seek(
+            to: CMTime(seconds: seconds, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
+        ) { [weak self] _ in
+            self?.player.volume = 1
+            self?.isSeeking = false
+            print("seeked")
+        }
+    }
+    
+    @objc func playerDidFinishPlaying(note: NSNotification) {
+        print("items empty: \(player.items().count)")
+        if player.items().count <= 1 { stop() }
+        isSeeking = false
+        queue.remove(at: 0)
+    }
+    
+    init() {
+        let timeScale = CMTimeScale(NSEC_PER_SEC)
+        let time = CMTime(seconds: 0.5, preferredTimescale: timeScale)
+
+        timeObserverToken = player.addPeriodicTimeObserver(forInterval: time, queue: .main) {
+            [weak self] time in
+            guard !(self?.isSeeking ?? true) else { return }
+            self?.progress = time.seconds
+            if self?.player.currentItem?.duration.isValid ?? false {
+                self?.duration = (self?.player.currentItem?.duration.seconds ?? 0).fixNumbers()
+            }
+        }
+        
+        NotificationCenter.default.addObserver(self,
+            selector: #selector(playerDidFinishPlaying),
+            name: .AVPlayerItemDidPlayToEndTime,
+            object: player.currentItem
+        )
+    }
+    
+    deinit {
+        if let timeObserverToken = timeObserverToken {
+            player.removeTimeObserver(timeObserverToken)
+            self.timeObserverToken = nil
+        }
+    }
 }

--- a/Swiftcord/Utils/AudioCenterManager.swift
+++ b/Swiftcord/Utils/AudioCenterManager.swift
@@ -26,15 +26,20 @@ class AudioCenterManager: ObservableObject {
     @Published public var isStopped = true
     @Published public var isPlaying = false
     
-    public func append(source: URL, filename: String, from: String) {
+    public func append(source: URL, filename: String, from: String, at: Int? = nil) {
         let playerItem = AVPlayerItem(url: source)
-        player.insert(playerItem, after: nil)
-        queue.append(AudioCenterItems(
+        player.insert(playerItem,
+                      after: queue.isEmpty ? nil : queue[at ?? (queue.count - 1)].playerItem)
+        queue.insert(AudioCenterItems(
             playerItem: playerItem,
             filename: filename,
             from: from,
             addedAt: Int(Date().timeIntervalSince1970)
-        ))
+        ), at: at ?? queue.count)
+    }
+    
+    public func remove(at: Int) {
+        player.remove(queue.remove(at: at).playerItem)
     }
     
     public func play() {
@@ -46,13 +51,12 @@ class AudioCenterManager: ObservableObject {
         duration = 0
     }
     public func playQueued(index: Int) {
-        queue.swapAt(index, 0)
+        if index != 0 { queue.swapAt(index, 0) }
         player.pause()
         player.removeAllItems()
         for item in queue { player.insert(item.playerItem, after: nil) }
-        player.play()
         player.seek(to: CMTime.zero)
-        isPlaying = true
+        play()
     }
     public func resume() {
         player.volume = 1

--- a/Swiftcord/Utils/Extensions/FormatTime.swift
+++ b/Swiftcord/Utils/Extensions/FormatTime.swift
@@ -1,0 +1,26 @@
+//
+//  FormatCMTime.swift
+//  Swiftcord
+//
+//  Created by Vincent Kwok on 11/5/22.
+//
+
+import Foundation
+import AVFoundation
+
+extension Double {
+    // If the number is NaN or Infinite numbers, returns 0
+    func fixNumbers() -> Double {
+        self.isNaN || self.isInfinite ? 0 : self
+    }
+    
+    // Format seconds to ss:mm(:hh)
+    func humanReadableTime() -> String {
+        let hr = Int(self / 60 / 60),
+            min = Int(self.truncatingRemainder(dividingBy: 60*60) / 60),
+            sec = Int(self.truncatingRemainder(dividingBy: 60*60).truncatingRemainder(dividingBy: 60))
+        return hr > 0
+        ? String(format: "%02d:%02d:%02d", hr, min, sec)
+        : String(format: "%02d:%02d", min, sec)
+    }
+}

--- a/Swiftcord/Views/ContentView.swift
+++ b/Swiftcord/Views/ContentView.swift
@@ -30,6 +30,8 @@ struct ContentView: View {
     @State private var mediaCenterOpen: Bool = false
     
     @StateObject var loginWVModel: WebViewModel = WebViewModel(link: "https://canary.discord.com/login")
+    @StateObject private var audioManager = AudioCenterManager()
+    
     @EnvironmentObject var gateway: DiscordGateway
     @EnvironmentObject var state: UIState
     
@@ -88,6 +90,7 @@ struct ContentView: View {
             
             ServerView(guild: $selectedGuild)
         }
+        .environmentObject(audioManager)
         .toolbar {
             ToolbarItem {
                 Button(action: { mediaCenterOpen = true }, label: {
@@ -95,6 +98,7 @@ struct ContentView: View {
                 })
                 .popover(isPresented: $mediaCenterOpen) {
                     MediaControllerView()
+                        .environmentObject(audioManager)
                 }
             }
         }

--- a/Swiftcord/Views/ContentView.swift
+++ b/Swiftcord/Views/ContentView.swift
@@ -90,22 +90,20 @@ struct ContentView: View {
             
             ServerView(guild: $selectedGuild)
         }
-        .environmentObject(audioManager)
         .toolbar {
             ToolbarItem {
-                Button(action: { mediaCenterOpen = true }, label: {
-                    Image(systemName: "play.circle")
-                })
-                .popover(isPresented: $mediaCenterOpen) {
-                    MediaControllerView()
-                        .environmentObject(audioManager)
-                }
+                Button(action: { mediaCenterOpen = true }, label: { Image(systemName: "play.circle") })
+                    .popover(isPresented: $mediaCenterOpen) { MediaControllerView() }
             }
         }
-        .onChange(of: selectedGuild, perform: { _ in
+        .environmentObject(audioManager)
+        .onChange(of: audioManager.queue.count) { [oldCount = audioManager.queue.count] count in
+            if count > oldCount { mediaCenterOpen = true }
+        }
+        .onChange(of: selectedGuild) { _ in
             guard let id = selectedGuild?.id else { return }
             UserDefaults.standard.set(id, forKey: "lastSelectedGuild")
-        })
+        }
         .onChange(of: state.loadingState, perform: { state in
             if state == .gatewayConn {
                 if let lGID = UserDefaults.standard.string(forKey: "lastSelectedGuild") {

--- a/Swiftcord/Views/MediaControllerView.swift
+++ b/Swiftcord/Views/MediaControllerView.swift
@@ -19,7 +19,7 @@ struct MediaControllerView: View {
             
             Divider().padding(.vertical, 8)
             
-            Text(audioManager.isStopped ? "Nothing's Playing" : audioManager.queue[0].filename)
+            Text(audioManager.isStopped ? "Nothing's Playing" : audioManager.queue[0].filename.replacingOccurrences(of: "_", with: " "))
                 .font(.headline)
             Text(audioManager.isStopped
                  ? "Select an audio file in a channel to play it!"
@@ -73,7 +73,7 @@ struct MediaControllerView: View {
                         Button {
                             withAnimation { audioManager.playQueued(index: idx) }
                         } label: {
-                            Text(item.filename)
+                            Text(item.filename.replacingOccurrences(of: "_", with: " "))
                                 .frame(maxWidth: .infinity, alignment: .leading)
                         }
                         .buttonStyle(.borderedProminent)

--- a/Swiftcord/Views/MediaControllerView.swift
+++ b/Swiftcord/Views/MediaControllerView.swift
@@ -40,10 +40,10 @@ struct MediaControllerView: View {
             }
             
             HStack(spacing: 20) {
-                Button {
-                    
-                } label: {
-                    Image(systemName: "repeat.1").font(.system(size: 18)).opacity(0.77)
+                Button { audioManager.cycleLoopMode() } label: {
+                    Image(systemName: audioManager.loopMode == .single ? "repeat.1" : "repeat")
+                        .font(.system(size: 18)).opacity(0.8)
+                        .foregroundColor(audioManager.loopMode == .disabled ? .white: .accentColor)
                 }.buttonStyle(.plain).disabled(audioManager.isStopped)
                 
                 Button {
@@ -58,7 +58,7 @@ struct MediaControllerView: View {
                     audioManager.remove(at: 0)
                     audioManager.playQueued(index: 0)
                 } label: {
-                    Image(systemName: "forward.end.fill").font(.system(size: 18)).opacity(0.77)
+                    Image(systemName: "forward.end.fill").font(.system(size: 18)).opacity(0.8)
                 }
                 .buttonStyle(.plain)
                 .disabled(audioManager.isStopped || audioManager.queue.count == 1)

--- a/Swiftcord/Views/MediaControllerView.swift
+++ b/Swiftcord/Views/MediaControllerView.swift
@@ -8,25 +8,94 @@
 import SwiftUI
 
 struct MediaControllerView: View {
-    @State var progress = 0.0
+    @EnvironmentObject var audioManager: AudioCenterManager
+    
     @State private var isSeeking = false
+    @State private var progress = 0.0
     
     var body: some View {
-        VStack(spacing: 8) {
+        VStack(alignment: .leading, spacing: 0) {
             Text("Media Center").font(.title2).fontWeight(.semibold)
+            
+            Divider().padding(.vertical, 8)
+            
+            Text(audioManager.isStopped ? "Nothing's Playing" : audioManager.queue[0].filename)
+                .font(.headline)
+            Text(audioManager.isStopped
+                 ? "Select an audio file in a channel to play it!"
+                 : audioManager.queue[0].from)
+                .font(.subheadline).opacity(0.77)
+            
             Slider(
                 value: $progress,
-                in: 0...100
-            ) {
-            } minimumValueLabel: {
-                Text("0")
-            } maximumValueLabel: {
-                Text("100")
-            } onEditingChanged: { editing in
+                in: 0...audioManager.duration
+            ) { } onEditingChanged: { editing in
                 isSeeking = editing
+                if !editing { audioManager.seekTo(seconds: progress) }
+            }.padding(.top, 4).disabled(audioManager.isStopped)
+            HStack {
+                Text(progress.humanReadableTime())
+                Spacer()
+                Text(audioManager.duration.humanReadableTime())
             }
+            
+            HStack(spacing: 20) {
+                Button {
+                    
+                } label: {
+                    Image(systemName: "backward.end.fill").font(.system(size: 18)).opacity(0.77)
+                }.buttonStyle(.plain).disabled(audioManager.isStopped)
+                
+                Button {
+                    if audioManager.isPlaying { audioManager.pause() }
+                    else { audioManager.resume() }
+                } label: {
+                    Image(systemName: audioManager.isPlaying ? "pause.fill" : "play.fill")
+                        .font(.system(size: 32))
+                }.buttonStyle(.plain).disabled(audioManager.isStopped).frame(width: 34, height: 34)
+                
+                Button {
+                    
+                } label: {
+                    Image(systemName: "forward.end.fill").font(.system(size: 18)).opacity(0.77)
+                }.buttonStyle(.plain).disabled(audioManager.isStopped)
+            }.frame(maxWidth: .infinity)
+            
+            Divider().padding(.vertical, 8)
+            
+            Text("Up Next").font(.title3).fontWeight(.semibold)
+            ScrollView {
+                VStack(spacing: 4) {
+                    ForEach(Array(audioManager.queue.enumerated()), id: \.element) { idx, item in
+                        Button {
+                            withAnimation { audioManager.playQueued(index: idx) }
+                        } label: {
+                            Text(item.filename)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.large)
+                        .tint(idx == 0 ? .accentColor : .gray.opacity(0.5))
+                        .padding(.top, idx == 0 ? 8 : 0)
+                        .padding(.bottom, idx == audioManager.queue.count - 1 ? 12 : 0)
+                    }
+                    if audioManager.queue.isEmpty {
+                        Text("Nothing in queue")
+                            .opacity(0.77)
+                            .frame(maxWidth: .infinity)
+                            .padding(.bottom, 12)
+                    }
+                }
+            }
+            .padding(.bottom, -12)
+            .frame(maxHeight: 180)
         }
-        .frame(width: 400)
-        .padding()
+        .onAppear(perform: { progress = audioManager.progress })
+        .onChange(of: audioManager.progress, perform: { prog in
+            guard !isSeeking else { return }
+            progress = prog
+        })
+        .frame(width: 300)
+        .padding(12)
     }
 }

--- a/Swiftcord/Views/MediaControllerView.swift
+++ b/Swiftcord/Views/MediaControllerView.swift
@@ -43,7 +43,7 @@ struct MediaControllerView: View {
                 Button {
                     
                 } label: {
-                    Image(systemName: "backward.end.fill").font(.system(size: 18)).opacity(0.77)
+                    Image(systemName: "repeat.1").font(.system(size: 18)).opacity(0.77)
                 }.buttonStyle(.plain).disabled(audioManager.isStopped)
                 
                 Button {
@@ -55,10 +55,13 @@ struct MediaControllerView: View {
                 }.buttonStyle(.plain).disabled(audioManager.isStopped).frame(width: 34, height: 34)
                 
                 Button {
-                    
+                    audioManager.remove(at: 0)
+                    audioManager.playQueued(index: 0)
                 } label: {
                     Image(systemName: "forward.end.fill").font(.system(size: 18)).opacity(0.77)
-                }.buttonStyle(.plain).disabled(audioManager.isStopped)
+                }
+                .buttonStyle(.plain)
+                .disabled(audioManager.isStopped || audioManager.queue.count == 1)
             }.frame(maxWidth: .infinity)
             
             Divider().padding(.vertical, 8)

--- a/Swiftcord/Views/Message/AttachmentView.swift
+++ b/Swiftcord/Views/Message/AttachmentView.swift
@@ -81,13 +81,18 @@ struct AudioAttachmentView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 
                 Button {
-                    audioManager.append(source: url, filename: attachment.filename, from: "no")
+                    audioManager.append(source: url,
+                                        filename: attachment.filename,
+                                        from: "Source not implemented yet")
                 } label: {
                     Image(systemName: "text.append").font(.system(size: 18))
                 }.buttonStyle(.plain).help("Append to queue")
                 
                 Button {
-                    audioManager.append(source: url, filename: attachment.filename, from: "no", at: 0)
+                    audioManager.append(source: url,
+                                        filename: attachment.filename,
+                                        from: "Source not implemented yet",
+                                        at: 0)
                     audioManager.playQueued(index: 0)
                 } label: {
                     Image(systemName: "play.fill").font(.system(size: 20)).frame(width: 36, height: 36)

--- a/Swiftcord/Views/Message/AttachmentView.swift
+++ b/Swiftcord/Views/Message/AttachmentView.swift
@@ -62,6 +62,7 @@ struct AttachmentImage: View {
 struct AudioAttachmentView: View {
     let attachment: Attachment
     let url: URL
+    
     @EnvironmentObject var audioManager: AudioCenterManager
     
     var body: some View {
@@ -89,8 +90,11 @@ struct AudioAttachmentView: View {
                     audioManager.append(source: url, filename: attachment.filename, from: "no", at: 0)
                     audioManager.playQueued(index: 0)
                 } label: {
-                    Image(systemName: "play.fill").font(.system(size: 24))
-                }.buttonStyle(.plain).help("Play now")
+                    Image(systemName: "play.fill").font(.system(size: 20)).frame(width: 36, height: 36)
+                }
+                .buttonStyle(.plain)
+                .background(Circle().fill(Color.accentColor))
+                .help("Play now")
             }.padding(4)
         }.frame(width: 400)
     }

--- a/Swiftcord/Views/Message/AttachmentView.swift
+++ b/Swiftcord/Views/Message/AttachmentView.swift
@@ -66,11 +66,12 @@ struct AudioAttachmentView: View {
     
     var body: some View {
         GroupBox {
-            VStack(alignment: .leading) {
+            HStack() {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(attachment.filename)
                         .font(.system(size: 15))
                         .fontWeight(.medium)
+                        .truncationMode(.middle)
                         .lineLimit(1)
                     Text("\(attachment.size.humanReadableFileSize()) • \(attachment.filename.fileExtension.uppercased())")
                         .font(.caption)
@@ -78,10 +79,18 @@ struct AudioAttachmentView: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 
-                Button("Play") {
+                Button {
                     audioManager.append(source: url, filename: attachment.filename, from: "no")
-                    audioManager.play()
-                }
+                } label: {
+                    Image(systemName: "text.append").font(.system(size: 18))
+                }.buttonStyle(.plain).help("Append to queue")
+                
+                Button {
+                    audioManager.append(source: url, filename: attachment.filename, from: "no", at: 0)
+                    audioManager.playQueued(index: 0)
+                } label: {
+                    Image(systemName: "play.fill").font(.system(size: 24))
+                }.buttonStyle(.plain).help("Play now")
             }.padding(4)
         }.frame(width: 400)
     }

--- a/Swiftcord/Views/Message/AttachmentView.swift
+++ b/Swiftcord/Views/Message/AttachmentView.swift
@@ -59,6 +59,34 @@ struct AttachmentImage: View {
     }
 }
 
+struct AudioAttachmentView: View {
+    let attachment: Attachment
+    let url: URL
+    @EnvironmentObject var audioManager: AudioCenterManager
+    
+    var body: some View {
+        GroupBox {
+            VStack(alignment: .leading) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(attachment.filename)
+                        .font(.system(size: 15))
+                        .fontWeight(.medium)
+                        .lineLimit(1)
+                    Text("\(attachment.size.humanReadableFileSize()) • \(attachment.filename.fileExtension.uppercased())")
+                        .font(.caption)
+                        .opacity(0.5)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                
+                Button("Play") {
+                    audioManager.append(source: url, filename: attachment.filename, from: "no")
+                    audioManager.play()
+                }
+            }.padding(4)
+        }.frame(width: 400)
+    }
+}
+
 struct AttachmentView: View {
     let attachment: Attachment
     @State private var quickLookUrl: URL?
@@ -130,31 +158,9 @@ struct AttachmentView: View {
                             .clipShape(RoundedRectangle(cornerRadius: 4))
                     default: EmptyView()
                     }
-                }
-                else if mime.prefix(5) == "audio" {
-                    VStack(alignment: .leading) {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(attachment.filename)
-                                .font(.system(size: 15))
-                                .fontWeight(.medium)
-                                .lineLimit(1)
-                            Text("\(attachment.size.humanReadableFileSize()) • \(attachment.filename.fileExtension.uppercased())")
-                                .font(.caption)
-                                .opacity(0.5)
-                        }
-                        .padding(.top, 8)
-                        .padding([.leading, .trailing], 12)
-                        VideoPlayer(player: AVPlayer(url: url))
-                            .frame(maxWidth: .infinity, maxHeight: 42)
-                            .clipShape(RoundedRectangle(cornerRadius: 12))
-                    }
-                    .frame(width: 400)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(.gray.opacity(0.2), lineWidth: 1)
-                    )
-                }
-                else {
+                } else if mime.prefix(5) == "audio" {
+                    AudioAttachmentView(attachment: attachment, url: url)
+                } else {
                     // Display a generic file
                     GroupBox {
                         HStack(alignment: .center, spacing: 4) {

--- a/Swiftcord/Views/Server/ServerView.swift
+++ b/Swiftcord/Views/Server/ServerView.swift
@@ -7,8 +7,6 @@
 
 import SwiftUI
 
-// UserDefaults.standard.setValue(channel.id, forKey: "guildLastCh.\(guild!.id)")
-
 struct ServerView: View {
     @Binding var guild: Guild?
     @State private var channels: [Channel] = []
@@ -59,6 +57,7 @@ struct ServerView: View {
                 }
             }
             .toolbar {
+                // FIXME: This doesn't appear in the toolbar for some reason
                 ToolbarItemGroup {
                     Text(guild?.name ?? "Loading").font(.title3).fontWeight(.semibold)
                         .frame(minWidth: 0)


### PR DESCRIPTION
🎵 🎶 **Introducing: Swiftcord's Audio Manager!**
Ever wanted to play audio and browse other chats at the same time, or have the urge to listen to all the songs in your favourite album without leaving Swiftcord? This PR adds a central audio manager, where the playback of audio attachments can be controlled, and even includes a queue for adding your favourite audio attachments! Now, you can listen to uninterrupted audio while texting your friends or bots xD

<img width="816" alt="Screenshot 2022-05-11 at 8 59 05 PM" src="https://user-images.githubusercontent.com/64193267/167855503-c85ba5b1-55a6-48b1-b01f-d28997d7bffc.png">
